### PR TITLE
chore: release  chart 0.2.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   ".": "0.1.0",
-  "charts/thymus": "0.2.1"
+  "charts/thymus": "0.2.2"
 }

--- a/charts/thymus/CHANGELOG.md
+++ b/charts/thymus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.2](https://github.com/carbynestack/thymus/compare/chart-v0.2.1...chart-v0.2.2) (2024-06-05)
+
+
+### Bug Fixes
+
+* use latest actions because of node image deprecation ([28663e1](https://github.com/carbynestack/thymus/commit/28663e1db2bc66ebdd68016d28c183b35b05c3f8))
+
 ## [0.2.1](https://github.com/carbynestack/thymus/compare/chart-v0.2.0...chart-v0.2.1) (2024-06-05)
 
 

--- a/charts/thymus/Chart.yaml
+++ b/charts/thymus/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v2
 name: thymus
 description: Helm Chart for the Thymus Authentication and Authorization Subsystem.
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.1.0
 dependencies:
   - name: kratos


### PR DESCRIPTION
:package: Staging a new release
---


## [0.2.2](https://github.com/carbynestack/thymus/compare/chart-v0.2.1...chart-v0.2.2) (2024-06-05)


### Bug Fixes

* use latest actions because of node image deprecation ([28663e1](https://github.com/carbynestack/thymus/commit/28663e1db2bc66ebdd68016d28c183b35b05c3f8))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).