### PR TITLE
chore: release  chart 0.2.3

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   ".": "0.1.0",
-  "charts/thymus": "0.2.2"
+  "charts/thymus": "0.2.3"
 }

--- a/charts/thymus/CHANGELOG.md
+++ b/charts/thymus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.3](https://github.com/carbynestack/thymus/compare/chart-v0.2.2...chart-v0.2.3) (2024-06-05)
+
+
+### Bug Fixes
+
+* trigger chart publication ([192f8c4](https://github.com/carbynestack/thymus/commit/192f8c4fc57a5b7c6ad336a08d7375ddce8d2656))
+
 ## [0.2.2](https://github.com/carbynestack/thymus/compare/chart-v0.2.1...chart-v0.2.2) (2024-06-05)
 
 

--- a/charts/thymus/Chart.yaml
+++ b/charts/thymus/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v2
 name: thymus
 description: Helm Chart for the Thymus Authentication and Authorization Subsystem.
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.1.0
 dependencies:
   - name: kratos


### PR DESCRIPTION
:package: Staging a new release
---


## [0.2.3](https://github.com/carbynestack/thymus/compare/chart-v0.2.2...chart-v0.2.3) (2024-06-05)


### Bug Fixes

* trigger chart publication ([192f8c4](https://github.com/carbynestack/thymus/commit/192f8c4fc57a5b7c6ad336a08d7375ddce8d2656))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).