### PR TITLE
chore: release  chart 0.4.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "services": "0.2.1",
-  "charts/thymus": "0.3.0",
+  "charts/thymus": "0.4.0",
   "clients/java": "0.2.0"
 }

--- a/charts/thymus/CHANGELOG.md
+++ b/charts/thymus/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.4.0](https://github.com/carbynestack/thymus/compare/chart-v0.3.0...chart-v0.4.0) (2024-11-13)
+
+
+### ⚠ BREAKING CHANGES
+
+* **chart:** move policy catalogue values from root into thymus container ([#26](https://github.com/carbynestack/thymus/issues/26))
+
+### Bug Fixes
+
+* **chart:** move policy catalogue values from root into thymus container ([#26](https://github.com/carbynestack/thymus/issues/26)) ([43ed16f](https://github.com/carbynestack/thymus/commit/43ed16fca5cffe053df09a6a08bda9ccce7d8ec6))
+
 ## [0.3.0](https://github.com/carbynestack/thymus/compare/chart-v0.2.4...chart-v0.3.0) (2024-11-13)
 
 

--- a/charts/thymus/Chart.yaml
+++ b/charts/thymus/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v2
 name: thymus
 description: Helm Chart for the Thymus Authentication and Authorization Subsystem.
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: 0.1.0
 dependencies:
   - name: kratos


### PR DESCRIPTION
:package: Staging a new release
---


## [0.4.0](https://github.com/carbynestack/thymus/compare/chart-v0.3.0...chart-v0.4.0) (2024-11-13)


### ⚠ BREAKING CHANGES

* **chart:** move policy catalogue values from root into thymus container ([#26](https://github.com/carbynestack/thymus/issues/26))

### Bug Fixes

* **chart:** move policy catalogue values from root into thymus container ([#26](https://github.com/carbynestack/thymus/issues/26)) ([43ed16f](https://github.com/carbynestack/thymus/commit/43ed16fca5cffe053df09a6a08bda9ccce7d8ec6))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).