### PR TITLE
chore: release  chart 0.6.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "services": "0.2.1",
-  "charts/thymus": "0.5.0",
+  "charts/thymus": "0.6.0",
   "clients/java": "0.3.0"
 }

--- a/charts/thymus/CHANGELOG.md
+++ b/charts/thymus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.0](https://github.com/carbynestack/thymus/compare/chart-v0.5.0...chart-v0.6.0) (2024-12-19)
+
+
+### Features
+
+* **chart:** add contributor list to generated tags ([#38](https://github.com/carbynestack/thymus/issues/38)) ([27366e4](https://github.com/carbynestack/thymus/commit/27366e450ecb9055e027ac2a96bc5a7360981153))
+
 ## [0.5.0](https://github.com/carbynestack/thymus/compare/chart-v0.4.0...chart-v0.5.0) (2024-12-18)
 
 

--- a/charts/thymus/Chart.yaml
+++ b/charts/thymus/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v2
 name: thymus
 description: Helm Chart for the Thymus Authentication and Authorization Subsystem.
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: 0.1.0
 dependencies:
   - name: kratos


### PR DESCRIPTION
:package: Staging a new release
---


## [0.6.0](https://github.com/carbynestack/thymus/compare/chart-v0.5.0...chart-v0.6.0) (2024-12-19)


### Features

* **chart:** add contributor list to generated tags ([#38](https://github.com/carbynestack/thymus/issues/38)) ([27366e4](https://github.com/carbynestack/thymus/commit/27366e450ecb9055e027ac2a96bc5a7360981153))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).