### PR TITLE
chore: release  chart 0.6.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "services": "0.2.1",
-  "charts/thymus": "0.6.0",
+  "charts/thymus": "0.6.1",
   "clients/java": "0.3.0"
 }

--- a/charts/thymus/CHANGELOG.md
+++ b/charts/thymus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.1](https://github.com/carbynestack/thymus/compare/chart-v0.6.0...chart-v0.6.1) (2024-12-19)
+
+
+### Bug Fixes
+
+* **chart:** add missing client scope "email" ([#40](https://github.com/carbynestack/thymus/issues/40)) ([d0fbc6f](https://github.com/carbynestack/thymus/commit/d0fbc6f3ad120040dceb9d8b0cac24ac70bd4108))
+
 ## [0.6.0](https://github.com/carbynestack/thymus/compare/chart-v0.5.0...chart-v0.6.0) (2024-12-19)
 
 

--- a/charts/thymus/Chart.yaml
+++ b/charts/thymus/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v2
 name: thymus
 description: Helm Chart for the Thymus Authentication and Authorization Subsystem.
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.1.0
 dependencies:
   - name: kratos


### PR DESCRIPTION
:package: Staging a new release
---


## [0.6.1](https://github.com/carbynestack/thymus/compare/chart-v0.6.0...chart-v0.6.1) (2024-12-19)


### Bug Fixes

* **chart:** add missing client scope "email" ([#40](https://github.com/carbynestack/thymus/issues/40)) ([d0fbc6f](https://github.com/carbynestack/thymus/commit/d0fbc6f3ad120040dceb9d8b0cac24ac70bd4108))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).