### PR TITLE
chore: release  chart 0.6.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "services": "0.2.1",
-  "charts/thymus": "0.6.1",
+  "charts/thymus": "0.6.2",
   "clients/java": "0.3.0"
 }

--- a/charts/thymus/CHANGELOG.md
+++ b/charts/thymus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.2](https://github.com/carbynestack/thymus/compare/chart-v0.6.1...chart-v0.6.2) (2025-03-07)
+
+
+### Bug Fixes
+
+* **chart:** make virtualservice use defined gateway ([#42](https://github.com/carbynestack/thymus/issues/42)) ([fef7400](https://github.com/carbynestack/thymus/commit/fef7400510843a6f699a10f3f5dcd7790bdaba0e))
+
 ## [0.6.1](https://github.com/carbynestack/thymus/compare/chart-v0.6.0...chart-v0.6.1) (2024-12-19)
 
 

--- a/charts/thymus/Chart.yaml
+++ b/charts/thymus/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v2
 name: thymus
 description: Helm Chart for the Thymus Authentication and Authorization Subsystem.
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.1.0
 dependencies:
   - name: kratos


### PR DESCRIPTION
:package: Staging a new release
---


## [0.6.2](https://github.com/carbynestack/thymus/compare/chart-v0.6.1...chart-v0.6.2) (2025-03-07)


### Bug Fixes

* **chart:** make virtualservice use defined gateway ([#42](https://github.com/carbynestack/thymus/issues/42)) ([fef7400](https://github.com/carbynestack/thymus/commit/fef7400510843a6f699a10f3f5dcd7790bdaba0e))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).